### PR TITLE
Misc fixes discovered when parsing every error in Symfony docs

### DIFF
--- a/src/Command/CheckDocsCommand.php
+++ b/src/Command/CheckDocsCommand.php
@@ -130,7 +130,7 @@ class CheckDocsCommand extends Command
                 $this->io->error(sprintf('Build completed with %s errors', $issueCount));
             } elseif ('github' === $format) {
                 foreach ($issues as $issue) {
-                    $this->io->writeln(sprintf('::error file=%s.rst,line=%s::[%s] %s', $issue->getFile(), $issue->getLine(), $issue->getType(), str_replace(PHP_EOL, ' ', $issue->getText())));
+                    $this->io->writeln(sprintf('::error file=%s,line=%s::[%s] %s', $issue->getFile(), $issue->getLine(), $issue->getType(), str_replace(PHP_EOL, ' ', $issue->getText())));
                 }
             }
 

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -56,7 +56,7 @@ class Issue implements \Stringable
 
     public function getFile(): string
     {
-        return $this->file;
+        return $this->file.'.rst';
     }
 
     public function getLine(): int

--- a/src/Service/CodeNodeRunner.php
+++ b/src/Service/CodeNodeRunner.php
@@ -31,7 +31,7 @@ class CodeNodeRunner
     private function processNode(CodeNode $node, IssueCollection $issues, string $applicationDirectory): void
     {
         $file = $this->getFile($node);
-        if ('config/' !== substr($file, 0, 7)) {
+        if ('config/packages/' !== substr($file, 0, 7)) {
             return;
         }
 

--- a/src/Service/CodeNodeRunner.php
+++ b/src/Service/CodeNodeRunner.php
@@ -31,7 +31,7 @@ class CodeNodeRunner
     private function processNode(CodeNode $node, IssueCollection $issues, string $applicationDirectory): void
     {
         $file = $this->getFile($node);
-        if ('config/packages/' !== substr($file, 0, 7)) {
+        if ('config/packages/' !== substr($file, 0, 16)) {
             return;
         }
 

--- a/src/Service/CodeValidator/PhpValidator.php
+++ b/src/Service/CodeValidator/PhpValidator.php
@@ -18,7 +18,7 @@ class PhpValidator implements Validator
 
         $file = sys_get_temp_dir().'/'.uniqid('doc_builder', true).'.php';
         $contents = $node->getValue();
-        if (!preg_match('#class [a-zA-Z]+#s', $contents) && preg_match('#(public|protected|private) (\$[a-z]+|function)#s', $contents)) {
+        if (!preg_match('#(class|interface) [a-zA-Z]+#s', $contents) && preg_match('#(public|protected|private)( static)? (\$[a-z]+|function)#s', $contents)) {
             $contents = 'class Foobar {'.$contents.'}';
         }
 

--- a/src/Service/CodeValidator/TwigValidator.php
+++ b/src/Service/CodeValidator/TwigValidator.php
@@ -31,7 +31,7 @@ class TwigValidator implements Validator
             // We cannot parse the TokenStream because we dont have all extensions loaded.
             $this->twig->parse($tokens);
         } catch (SyntaxError $e) {
-            $issues->addIssue(new Issue($node, $e->getMessage(), 'Invalid syntax', $node->getEnvironment()->getCurrentFileName(), 0));
+            $issues->addIssue(new Issue($node, $e->getRawMessage(), 'Twig', $node->getEnvironment()->getCurrentFileName(), $e->getTemplateLine()));
         }
     }
 }

--- a/src/Service/CodeValidator/YamlValidator.php
+++ b/src/Service/CodeValidator/YamlValidator.php
@@ -25,7 +25,7 @@ class YamlValidator implements Validator
                 return;
             }
 
-            $issues->addIssue(new Issue($node, $e->getMessage(), 'Invalid syntax', $node->getEnvironment()->getCurrentFileName(), 0));
+            $issues->addIssue(new Issue($node, $e->getMessage(), 'Invalid syntax', $node->getEnvironment()->getCurrentFileName(), $e->getParsedLine()));
         }
     }
 }

--- a/src/Twig/DummyExtension.php
+++ b/src/Twig/DummyExtension.php
@@ -77,6 +77,9 @@ class DummyExtension extends AbstractExtension
             new TwigFilter('yaml_dump'),
             new TwigFilter('trans'),
             new TwigFilter('transchoice'),
+            new TwigFilter('inline_css'),
+            new TwigFilter('markdown_to_html'),
+            new TwigFilter('inky_to_html'),
         ];
     }
 }

--- a/src/Twig/DummyExtension.php
+++ b/src/Twig/DummyExtension.php
@@ -55,6 +55,8 @@ class DummyExtension extends AbstractExtension
             new TwigFunction('workflow_marked_places'),
             new TwigFunction('workflow_metadata'),
             new TwigFunction('workflow_transition_blockers'),
+            new TwigFunction('encore_entry_link_tags'),
+            new TwigFunction('encore_entry_script_tags'),
         ];
     }
 

--- a/tests/Service/Validator/PhpValidatorTest.php
+++ b/tests/Service/Validator/PhpValidatorTest.php
@@ -22,19 +22,54 @@ class PhpValidatorTest extends TestCase
         $this->validator = new PhpValidator();
     }
 
-    public function testValid()
+    /**
+     * @dataProvider getCodeExamples
+     */
+    public function testCodeExamples(int $errors, string $code)
     {
-        $code ='
-$dummy = new class {
-    public $foo;
-    public $bar = "notNull";
-};';
-
         $node = new CodeNode(explode(PHP_EOL, $code));
         $node->setEnvironment($this->environment);
         $node->setLanguage('php');
         $issues = new IssueCollection();
         $this->validator->validate($node, $issues);
-        $this->assertCount(0, $issues);
+        $this->assertCount($errors, $issues);
+    }
+
+    public function getCodeExamples(): iterable
+    {
+        yield [0, '
+namespace Symfony\Component\HttpKernel;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface HttpKernelInterface
+{
+    // ...
+
+    /**
+     * @return Response A Response instance
+     */
+    public function handle(
+        Request $request,
+        $type = self::MASTER_REQUEST,
+        $catch = true
+    );
+}
+'];
+        yield [0, '
+public static function validate($object, ExecutionContextInterface $context, $payload)
+{
+    // somehow you have an array of "fake names"
+    $fakeNames = [/* ... */];
+
+    // check if the name is actually a fake name
+    if (in_array($object->getFirstName(), $fakeNames)) {
+        $context->buildViolation("This name sounds totally fake!")
+            ->atPath("firstName")
+            ->addViolation()
+        ;
+    }
+}
+'];
     }
 }

--- a/tests/Service/Validator/PhpValidatorTest.php
+++ b/tests/Service/Validator/PhpValidatorTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\CodeBlockChecker\Issue\IssueCollection;
 use Symfony\CodeBlockChecker\Service\CodeValidator\PhpValidator;
 use Symfony\CodeBlockChecker\Service\CodeValidator\Validator;
-use Symfony\CodeBlockChecker\Service\CodeValidator\YamlValidator;
 
 class PhpValidatorTest extends TestCase
 {

--- a/tests/Service/Validator/PhpValidatorTest.php
+++ b/tests/Service/Validator/PhpValidatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symfony\CodeBlockChecker\Tests\Service\Validator;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use Doctrine\RST\Nodes\CodeNode;
+use PHPUnit\Framework\TestCase;
+use Symfony\CodeBlockChecker\Issue\IssueCollection;
+use Symfony\CodeBlockChecker\Service\CodeValidator\PhpValidator;
+use Symfony\CodeBlockChecker\Service\CodeValidator\Validator;
+use Symfony\CodeBlockChecker\Service\CodeValidator\YamlValidator;
+
+class PhpValidatorTest extends TestCase
+{
+    private Validator $validator;
+    private Environment $environment;
+
+    protected function setUp(): void
+    {
+        $this->environment = new Environment(new Configuration());
+        $this->validator = new PhpValidator();
+    }
+
+    public function testValid()
+    {
+        $code ='
+$dummy = new class {
+    public $foo;
+    public $bar = "notNull";
+};';
+
+        $node = new CodeNode(explode(PHP_EOL, $code));
+        $node->setEnvironment($this->environment);
+        $node->setLanguage('php');
+        $issues = new IssueCollection();
+        $this->validator->validate($node, $issues);
+        $this->assertCount(0, $issues);
+    }
+}


### PR DESCRIPTION
We want to skip `/config/validator/` etc